### PR TITLE
build(deps): bump the aws-sdk-dependencies group across 1 directory w…

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "packageManager": "yarn@3.6.3",
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@aws-sdk/client-ecr": "^3.583.0",
-    "@aws-sdk/client-ecr-public": "^3.583.0",
+    "@aws-sdk/client-ecr": "^3.651.1",
+    "@aws-sdk/client-ecr-public": "^3.651.1",
     "@docker/actions-toolkit": "^0.35.0",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,513 +165,508 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/ie11-detection@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
+"@aws-crypto/sha256-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-browser@npm:5.2.0"
   dependencies:
-    tslib: ^1.11.1
-  checksum: 299b2ddd46eddac1f2d54d91386ceb37af81aef8a800669281c73d634ed17fd855dcfb8b3157f2879344b93a2666a6d602550eb84b71e4d7868100ad6da8f803
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/sha256-browser@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@aws-crypto/sha256-browser@npm:3.0.0"
-  dependencies:
-    "@aws-crypto/ie11-detection": ^3.0.0
-    "@aws-crypto/sha256-js": ^3.0.0
-    "@aws-crypto/supports-web-crypto": ^3.0.0
-    "@aws-crypto/util": ^3.0.0
+    "@aws-crypto/sha256-js": ^5.2.0
+    "@aws-crypto/supports-web-crypto": ^5.2.0
+    "@aws-crypto/util": ^5.2.0
     "@aws-sdk/types": ^3.222.0
     "@aws-sdk/util-locate-window": ^3.0.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: ca89456bf508db2e08060a7f656460db97ac9a15b11e39d6fa7665e2b156508a1758695bff8e82d0a00178d6ac5c36f35eb4bcfac2e48621265224ca14a19bd2
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.6.2
+  checksum: 773f12f2026d82a6bb4a23a8f491894a6d32525bd9b8bfbc12896526cf11882a7607a671c478c45f9cd7d6ba1caaed48a62b67c6f725244bd83a1275108f46c7
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@aws-crypto/sha256-js@npm:3.0.0"
+"@aws-crypto/sha256-js@npm:5.2.0, @aws-crypto/sha256-js@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-js@npm:5.2.0"
   dependencies:
-    "@aws-crypto/util": ^3.0.0
+    "@aws-crypto/util": ^5.2.0
     "@aws-sdk/types": ^3.222.0
-    tslib: ^1.11.1
-  checksum: 644ded32ea310237811afae873d3c7320739cb6f6cc39dced9c94801379e68e5ee2cca0c34f0384793fa9e750a7e0a5e2468f95754bd08e6fd72ab833c8fe23c
+    tslib: ^2.6.2
+  checksum: 007fbe0436d714d0d0d282e2b61c90e45adcb9ad75eac9ac7ba03d32b56624afd09b2a9ceb4d659661cf17c51d74d1900ab6b00eacafc002da1101664955ca53
   languageName: node
   linkType: hard
 
-"@aws-crypto/supports-web-crypto@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@aws-crypto/supports-web-crypto@npm:3.0.0"
+"@aws-crypto/supports-web-crypto@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:5.2.0"
   dependencies:
-    tslib: ^1.11.1
-  checksum: 35479a1558db9e9a521df6877a99f95670e972c602f2a0349303477e5d638a5baf569fb037c853710e382086e6fd77e8ed58d3fb9b49f6e1186a9d26ce7be006
+    tslib: ^2.6.2
+  checksum: 6ffc21de48b2b2c3e918193101d7e8fe949d47b37688892e1c39eaedaa938be80c0f404fe1c874c30cce16781026777a53bf47d5d90143ca91d0feb7c4a6f830
   languageName: node
   linkType: hard
 
-"@aws-crypto/util@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@aws-crypto/util@npm:3.0.0"
+"@aws-crypto/util@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/util@npm:5.2.0"
   dependencies:
     "@aws-sdk/types": ^3.222.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: d29d5545048721aae3d60b236708535059733019a105f8a64b4e4a8eab7cf8dde1546dc56bff7de20d36140a4d1f0f4693e639c5732a7059273a7b1e56354776
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.6.2
+  checksum: f0f81d9d2771c59946cfec48b86cb23d39f78a966c4a1f89d4753abdc3cb38de06f907d1e6450059b121d48ac65d612ab88bdb70014553a077fc3dabddfbf8d6
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-ecr-public@npm:^3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/client-ecr-public@npm:3.583.0"
+"@aws-sdk/client-ecr-public@npm:^3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/client-ecr-public@npm:3.651.1"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sso-oidc": 3.583.0
-    "@aws-sdk/client-sts": 3.583.0
-    "@aws-sdk/core": 3.582.0
-    "@aws-sdk/credential-provider-node": 3.583.0
-    "@aws-sdk/middleware-host-header": 3.577.0
-    "@aws-sdk/middleware-logger": 3.577.0
-    "@aws-sdk/middleware-recursion-detection": 3.577.0
-    "@aws-sdk/middleware-user-agent": 3.583.0
-    "@aws-sdk/region-config-resolver": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@aws-sdk/util-endpoints": 3.583.0
-    "@aws-sdk/util-user-agent-browser": 3.577.0
-    "@aws-sdk/util-user-agent-node": 3.577.0
-    "@smithy/config-resolver": ^3.0.0
-    "@smithy/core": ^2.0.1
-    "@smithy/fetch-http-handler": ^3.0.1
-    "@smithy/hash-node": ^3.0.0
-    "@smithy/invalid-dependency": ^3.0.0
-    "@smithy/middleware-content-length": ^3.0.0
-    "@smithy/middleware-endpoint": ^3.0.0
-    "@smithy/middleware-retry": ^3.0.1
-    "@smithy/middleware-serde": ^3.0.0
-    "@smithy/middleware-stack": ^3.0.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/node-http-handler": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/url-parser": ^3.0.0
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/client-sso-oidc": 3.651.1
+    "@aws-sdk/client-sts": 3.651.1
+    "@aws-sdk/core": 3.651.1
+    "@aws-sdk/credential-provider-node": 3.651.1
+    "@aws-sdk/middleware-host-header": 3.649.0
+    "@aws-sdk/middleware-logger": 3.649.0
+    "@aws-sdk/middleware-recursion-detection": 3.649.0
+    "@aws-sdk/middleware-user-agent": 3.649.0
+    "@aws-sdk/region-config-resolver": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@aws-sdk/util-endpoints": 3.649.0
+    "@aws-sdk/util-user-agent-browser": 3.649.0
+    "@aws-sdk/util-user-agent-node": 3.649.0
+    "@smithy/config-resolver": ^3.0.6
+    "@smithy/core": ^2.4.1
+    "@smithy/fetch-http-handler": ^3.2.5
+    "@smithy/hash-node": ^3.0.4
+    "@smithy/invalid-dependency": ^3.0.4
+    "@smithy/middleware-content-length": ^3.0.6
+    "@smithy/middleware-endpoint": ^3.1.1
+    "@smithy/middleware-retry": ^3.0.16
+    "@smithy/middleware-serde": ^3.0.4
+    "@smithy/middleware-stack": ^3.0.4
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/node-http-handler": ^3.2.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/smithy-client": ^3.3.0
+    "@smithy/types": ^3.4.0
+    "@smithy/url-parser": ^3.0.4
     "@smithy/util-base64": ^3.0.0
     "@smithy/util-body-length-browser": ^3.0.0
     "@smithy/util-body-length-node": ^3.0.0
-    "@smithy/util-defaults-mode-browser": ^3.0.1
-    "@smithy/util-defaults-mode-node": ^3.0.1
-    "@smithy/util-endpoints": ^2.0.0
-    "@smithy/util-middleware": ^3.0.0
-    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.16
+    "@smithy/util-defaults-mode-node": ^3.0.16
+    "@smithy/util-endpoints": ^2.1.0
+    "@smithy/util-middleware": ^3.0.4
+    "@smithy/util-retry": ^3.0.4
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
-  checksum: 858f05bf4ade9d199b64187845fcf47208b37e0829948ebbb0431f85399fde7f4e6ecf5e273c8a439a2777a5640a4d624d66173971d4898233950a40aff7d6e7
+  checksum: f326916abdec3ac4abba91700404bd9be75aa551d4ba0e088f4edbbeffe766873bf10522f265f03586e30cc014c3ac5c33f09334eac04f95ed06de622126d828
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-ecr@npm:^3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/client-ecr@npm:3.583.0"
+"@aws-sdk/client-ecr@npm:^3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/client-ecr@npm:3.651.1"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sso-oidc": 3.583.0
-    "@aws-sdk/client-sts": 3.583.0
-    "@aws-sdk/core": 3.582.0
-    "@aws-sdk/credential-provider-node": 3.583.0
-    "@aws-sdk/middleware-host-header": 3.577.0
-    "@aws-sdk/middleware-logger": 3.577.0
-    "@aws-sdk/middleware-recursion-detection": 3.577.0
-    "@aws-sdk/middleware-user-agent": 3.583.0
-    "@aws-sdk/region-config-resolver": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@aws-sdk/util-endpoints": 3.583.0
-    "@aws-sdk/util-user-agent-browser": 3.577.0
-    "@aws-sdk/util-user-agent-node": 3.577.0
-    "@smithy/config-resolver": ^3.0.0
-    "@smithy/core": ^2.0.1
-    "@smithy/fetch-http-handler": ^3.0.1
-    "@smithy/hash-node": ^3.0.0
-    "@smithy/invalid-dependency": ^3.0.0
-    "@smithy/middleware-content-length": ^3.0.0
-    "@smithy/middleware-endpoint": ^3.0.0
-    "@smithy/middleware-retry": ^3.0.1
-    "@smithy/middleware-serde": ^3.0.0
-    "@smithy/middleware-stack": ^3.0.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/node-http-handler": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/url-parser": ^3.0.0
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/client-sso-oidc": 3.651.1
+    "@aws-sdk/client-sts": 3.651.1
+    "@aws-sdk/core": 3.651.1
+    "@aws-sdk/credential-provider-node": 3.651.1
+    "@aws-sdk/middleware-host-header": 3.649.0
+    "@aws-sdk/middleware-logger": 3.649.0
+    "@aws-sdk/middleware-recursion-detection": 3.649.0
+    "@aws-sdk/middleware-user-agent": 3.649.0
+    "@aws-sdk/region-config-resolver": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@aws-sdk/util-endpoints": 3.649.0
+    "@aws-sdk/util-user-agent-browser": 3.649.0
+    "@aws-sdk/util-user-agent-node": 3.649.0
+    "@smithy/config-resolver": ^3.0.6
+    "@smithy/core": ^2.4.1
+    "@smithy/fetch-http-handler": ^3.2.5
+    "@smithy/hash-node": ^3.0.4
+    "@smithy/invalid-dependency": ^3.0.4
+    "@smithy/middleware-content-length": ^3.0.6
+    "@smithy/middleware-endpoint": ^3.1.1
+    "@smithy/middleware-retry": ^3.0.16
+    "@smithy/middleware-serde": ^3.0.4
+    "@smithy/middleware-stack": ^3.0.4
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/node-http-handler": ^3.2.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/smithy-client": ^3.3.0
+    "@smithy/types": ^3.4.0
+    "@smithy/url-parser": ^3.0.4
     "@smithy/util-base64": ^3.0.0
     "@smithy/util-body-length-browser": ^3.0.0
     "@smithy/util-body-length-node": ^3.0.0
-    "@smithy/util-defaults-mode-browser": ^3.0.1
-    "@smithy/util-defaults-mode-node": ^3.0.1
-    "@smithy/util-endpoints": ^2.0.0
-    "@smithy/util-middleware": ^3.0.0
-    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.16
+    "@smithy/util-defaults-mode-node": ^3.0.16
+    "@smithy/util-endpoints": ^2.1.0
+    "@smithy/util-middleware": ^3.0.4
+    "@smithy/util-retry": ^3.0.4
     "@smithy/util-utf8": ^3.0.0
-    "@smithy/util-waiter": ^3.0.0
+    "@smithy/util-waiter": ^3.1.3
     tslib: ^2.6.2
-  checksum: fb9ed45d8a55f69db82e4ba84215d19617a4aee60527265c0c7b5abc8c03a991761abda1b0c9ccc0cb7debe4b5c108c8f7fcb085d070d9028207c92418c52b8b
+  checksum: 10418e57c312d654d95b1dd3f1656fb3679e850cece8f2f6ee9286e5445483c4db11360ac5680f8e88aaa9145b9caf5a267b3667dbe6c05089e01653367efff6
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso-oidc@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/client-sso-oidc@npm:3.583.0"
+"@aws-sdk/client-sso-oidc@npm:3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.651.1"
   dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.583.0
-    "@aws-sdk/core": 3.582.0
-    "@aws-sdk/credential-provider-node": 3.583.0
-    "@aws-sdk/middleware-host-header": 3.577.0
-    "@aws-sdk/middleware-logger": 3.577.0
-    "@aws-sdk/middleware-recursion-detection": 3.577.0
-    "@aws-sdk/middleware-user-agent": 3.583.0
-    "@aws-sdk/region-config-resolver": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@aws-sdk/util-endpoints": 3.583.0
-    "@aws-sdk/util-user-agent-browser": 3.577.0
-    "@aws-sdk/util-user-agent-node": 3.577.0
-    "@smithy/config-resolver": ^3.0.0
-    "@smithy/core": ^2.0.1
-    "@smithy/fetch-http-handler": ^3.0.1
-    "@smithy/hash-node": ^3.0.0
-    "@smithy/invalid-dependency": ^3.0.0
-    "@smithy/middleware-content-length": ^3.0.0
-    "@smithy/middleware-endpoint": ^3.0.0
-    "@smithy/middleware-retry": ^3.0.1
-    "@smithy/middleware-serde": ^3.0.0
-    "@smithy/middleware-stack": ^3.0.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/node-http-handler": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/url-parser": ^3.0.0
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.651.1
+    "@aws-sdk/credential-provider-node": 3.651.1
+    "@aws-sdk/middleware-host-header": 3.649.0
+    "@aws-sdk/middleware-logger": 3.649.0
+    "@aws-sdk/middleware-recursion-detection": 3.649.0
+    "@aws-sdk/middleware-user-agent": 3.649.0
+    "@aws-sdk/region-config-resolver": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@aws-sdk/util-endpoints": 3.649.0
+    "@aws-sdk/util-user-agent-browser": 3.649.0
+    "@aws-sdk/util-user-agent-node": 3.649.0
+    "@smithy/config-resolver": ^3.0.6
+    "@smithy/core": ^2.4.1
+    "@smithy/fetch-http-handler": ^3.2.5
+    "@smithy/hash-node": ^3.0.4
+    "@smithy/invalid-dependency": ^3.0.4
+    "@smithy/middleware-content-length": ^3.0.6
+    "@smithy/middleware-endpoint": ^3.1.1
+    "@smithy/middleware-retry": ^3.0.16
+    "@smithy/middleware-serde": ^3.0.4
+    "@smithy/middleware-stack": ^3.0.4
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/node-http-handler": ^3.2.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/smithy-client": ^3.3.0
+    "@smithy/types": ^3.4.0
+    "@smithy/url-parser": ^3.0.4
     "@smithy/util-base64": ^3.0.0
     "@smithy/util-body-length-browser": ^3.0.0
     "@smithy/util-body-length-node": ^3.0.0
-    "@smithy/util-defaults-mode-browser": ^3.0.1
-    "@smithy/util-defaults-mode-node": ^3.0.1
-    "@smithy/util-endpoints": ^2.0.0
-    "@smithy/util-middleware": ^3.0.0
-    "@smithy/util-retry": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.16
+    "@smithy/util-defaults-mode-node": ^3.0.16
+    "@smithy/util-endpoints": ^2.1.0
+    "@smithy/util-middleware": ^3.0.4
+    "@smithy/util-retry": ^3.0.4
     "@smithy/util-utf8": ^3.0.0
-    tslib: ^2.6.2
-  checksum: 4f637e5c691560b0609ca8d1ab953379e1124529631d3e32043eb052f6ee65300245a16a8319460dc1a810854be667725be60657222f68b4833f83be03f4d6e7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/client-sso@npm:3.583.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/core": 3.582.0
-    "@aws-sdk/middleware-host-header": 3.577.0
-    "@aws-sdk/middleware-logger": 3.577.0
-    "@aws-sdk/middleware-recursion-detection": 3.577.0
-    "@aws-sdk/middleware-user-agent": 3.583.0
-    "@aws-sdk/region-config-resolver": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@aws-sdk/util-endpoints": 3.583.0
-    "@aws-sdk/util-user-agent-browser": 3.577.0
-    "@aws-sdk/util-user-agent-node": 3.577.0
-    "@smithy/config-resolver": ^3.0.0
-    "@smithy/core": ^2.0.1
-    "@smithy/fetch-http-handler": ^3.0.1
-    "@smithy/hash-node": ^3.0.0
-    "@smithy/invalid-dependency": ^3.0.0
-    "@smithy/middleware-content-length": ^3.0.0
-    "@smithy/middleware-endpoint": ^3.0.0
-    "@smithy/middleware-retry": ^3.0.1
-    "@smithy/middleware-serde": ^3.0.0
-    "@smithy/middleware-stack": ^3.0.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/node-http-handler": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/url-parser": ^3.0.0
-    "@smithy/util-base64": ^3.0.0
-    "@smithy/util-body-length-browser": ^3.0.0
-    "@smithy/util-body-length-node": ^3.0.0
-    "@smithy/util-defaults-mode-browser": ^3.0.1
-    "@smithy/util-defaults-mode-node": ^3.0.1
-    "@smithy/util-endpoints": ^2.0.0
-    "@smithy/util-middleware": ^3.0.0
-    "@smithy/util-retry": ^3.0.0
-    "@smithy/util-utf8": ^3.0.0
-    tslib: ^2.6.2
-  checksum: b9726eca5adad1b2f90f8b21d70b8c2619257f6b61e026e54caac781c24636ae63fbbf506e6086abd3aead5960fa4c11524c39bc37889e037b13dd565e5828db
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sts@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/client-sts@npm:3.583.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sso-oidc": 3.583.0
-    "@aws-sdk/core": 3.582.0
-    "@aws-sdk/credential-provider-node": 3.583.0
-    "@aws-sdk/middleware-host-header": 3.577.0
-    "@aws-sdk/middleware-logger": 3.577.0
-    "@aws-sdk/middleware-recursion-detection": 3.577.0
-    "@aws-sdk/middleware-user-agent": 3.583.0
-    "@aws-sdk/region-config-resolver": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@aws-sdk/util-endpoints": 3.583.0
-    "@aws-sdk/util-user-agent-browser": 3.577.0
-    "@aws-sdk/util-user-agent-node": 3.577.0
-    "@smithy/config-resolver": ^3.0.0
-    "@smithy/core": ^2.0.1
-    "@smithy/fetch-http-handler": ^3.0.1
-    "@smithy/hash-node": ^3.0.0
-    "@smithy/invalid-dependency": ^3.0.0
-    "@smithy/middleware-content-length": ^3.0.0
-    "@smithy/middleware-endpoint": ^3.0.0
-    "@smithy/middleware-retry": ^3.0.1
-    "@smithy/middleware-serde": ^3.0.0
-    "@smithy/middleware-stack": ^3.0.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/node-http-handler": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/url-parser": ^3.0.0
-    "@smithy/util-base64": ^3.0.0
-    "@smithy/util-body-length-browser": ^3.0.0
-    "@smithy/util-body-length-node": ^3.0.0
-    "@smithy/util-defaults-mode-browser": ^3.0.1
-    "@smithy/util-defaults-mode-node": ^3.0.1
-    "@smithy/util-endpoints": ^2.0.0
-    "@smithy/util-middleware": ^3.0.0
-    "@smithy/util-retry": ^3.0.0
-    "@smithy/util-utf8": ^3.0.0
-    tslib: ^2.6.2
-  checksum: a38f6996369c16f839e9d8a6e9f70937679f267efea83854ed43e6ca79342cd7e3caf6942672935a3ea818ebec64ea4caec0b69a2d1fa5adc170dd573cc09ecd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/core@npm:3.582.0":
-  version: 3.582.0
-  resolution: "@aws-sdk/core@npm:3.582.0"
-  dependencies:
-    "@smithy/core": ^2.0.1
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/signature-v4": ^3.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    fast-xml-parser: 4.2.5
-    tslib: ^2.6.2
-  checksum: 78f50015a7a13588c120a9a1a4a71bba2d04541aebaebe69249a083bf7ca0bdd3fc7a2985a88c386e77aeadc861470cc5aa56eaa24ec2f10981e4530cf6a57f9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-env@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.577.0"
-  dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/types": ^3.0.0
-    tslib: ^2.6.2
-  checksum: 155de3eafccc3eac6b94d53b4ec89b8f7ea313866e245f04887c4b0b274bcc4d04c9a1bc0c1cb7ae238a99aa032bf9c4eab6c1b1b676a06cce0de233ca0a7884
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-http@npm:3.582.0":
-  version: 3.582.0
-  resolution: "@aws-sdk/credential-provider-http@npm:3.582.0"
-  dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/fetch-http-handler": ^3.0.1
-    "@smithy/node-http-handler": ^3.0.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/util-stream": ^3.0.1
-    tslib: ^2.6.2
-  checksum: 19c466e2eaa0f1df4fd0bde89f5d8f5566229c852eab91e0b1b729871906fddc4fb6297278ffd2669c106e7ff991cc46864328b2cb136559a8fda119d83a1363
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.583.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.577.0
-    "@aws-sdk/credential-provider-process": 3.577.0
-    "@aws-sdk/credential-provider-sso": 3.583.0
-    "@aws-sdk/credential-provider-web-identity": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@smithy/credential-provider-imds": ^3.0.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/shared-ini-file-loader": ^3.0.0
-    "@smithy/types": ^3.0.0
     tslib: ^2.6.2
   peerDependencies:
-    "@aws-sdk/client-sts": ^3.583.0
-  checksum: 055116aa4f492bd972ef458026b20849e7297bd018fc77d11352e47622c416878582138c9cd23d581f8b8596dcc7918cce725a73982c7fdb11eec761fb34a19a
+    "@aws-sdk/client-sts": ^3.651.1
+  checksum: 14d43ee5c9fe6cae9115ea9b9a4c555409429f6a0f6e10919938abc3289f3cf76b42fabe1389963b54cd0f9c77a416ff334f1c482f48988723f8ba7004d82d07
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.583.0"
+"@aws-sdk/client-sso@npm:3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/client-sso@npm:3.651.1"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.577.0
-    "@aws-sdk/credential-provider-http": 3.582.0
-    "@aws-sdk/credential-provider-ini": 3.583.0
-    "@aws-sdk/credential-provider-process": 3.577.0
-    "@aws-sdk/credential-provider-sso": 3.583.0
-    "@aws-sdk/credential-provider-web-identity": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@smithy/credential-provider-imds": ^3.0.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/shared-ini-file-loader": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.651.1
+    "@aws-sdk/middleware-host-header": 3.649.0
+    "@aws-sdk/middleware-logger": 3.649.0
+    "@aws-sdk/middleware-recursion-detection": 3.649.0
+    "@aws-sdk/middleware-user-agent": 3.649.0
+    "@aws-sdk/region-config-resolver": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@aws-sdk/util-endpoints": 3.649.0
+    "@aws-sdk/util-user-agent-browser": 3.649.0
+    "@aws-sdk/util-user-agent-node": 3.649.0
+    "@smithy/config-resolver": ^3.0.6
+    "@smithy/core": ^2.4.1
+    "@smithy/fetch-http-handler": ^3.2.5
+    "@smithy/hash-node": ^3.0.4
+    "@smithy/invalid-dependency": ^3.0.4
+    "@smithy/middleware-content-length": ^3.0.6
+    "@smithy/middleware-endpoint": ^3.1.1
+    "@smithy/middleware-retry": ^3.0.16
+    "@smithy/middleware-serde": ^3.0.4
+    "@smithy/middleware-stack": ^3.0.4
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/node-http-handler": ^3.2.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/smithy-client": ^3.3.0
+    "@smithy/types": ^3.4.0
+    "@smithy/url-parser": ^3.0.4
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.16
+    "@smithy/util-defaults-mode-node": ^3.0.16
+    "@smithy/util-endpoints": ^2.1.0
+    "@smithy/util-middleware": ^3.0.4
+    "@smithy/util-retry": ^3.0.4
+    "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
-  checksum: e3bff754eb7d4baafffa9a5167b21314f3f7c84903d9a95ef17c29c38e82b33a5aa724119b540494dec94fab58a7b5e32782c851930f1d9e3468a644a558ad83
+  checksum: 07f4fe05e5b3d52bf34a93bb96539939d021045a3f02b7062d01edf22e13716fa82f137487096d4dd51f3e5428bd458a4fb5400246019aad5d913069ae419dcd
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.577.0"
+"@aws-sdk/client-sts@npm:3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/client-sts@npm:3.651.1"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/shared-ini-file-loader": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/client-sso-oidc": 3.651.1
+    "@aws-sdk/core": 3.651.1
+    "@aws-sdk/credential-provider-node": 3.651.1
+    "@aws-sdk/middleware-host-header": 3.649.0
+    "@aws-sdk/middleware-logger": 3.649.0
+    "@aws-sdk/middleware-recursion-detection": 3.649.0
+    "@aws-sdk/middleware-user-agent": 3.649.0
+    "@aws-sdk/region-config-resolver": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@aws-sdk/util-endpoints": 3.649.0
+    "@aws-sdk/util-user-agent-browser": 3.649.0
+    "@aws-sdk/util-user-agent-node": 3.649.0
+    "@smithy/config-resolver": ^3.0.6
+    "@smithy/core": ^2.4.1
+    "@smithy/fetch-http-handler": ^3.2.5
+    "@smithy/hash-node": ^3.0.4
+    "@smithy/invalid-dependency": ^3.0.4
+    "@smithy/middleware-content-length": ^3.0.6
+    "@smithy/middleware-endpoint": ^3.1.1
+    "@smithy/middleware-retry": ^3.0.16
+    "@smithy/middleware-serde": ^3.0.4
+    "@smithy/middleware-stack": ^3.0.4
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/node-http-handler": ^3.2.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/smithy-client": ^3.3.0
+    "@smithy/types": ^3.4.0
+    "@smithy/url-parser": ^3.0.4
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.16
+    "@smithy/util-defaults-mode-node": ^3.0.16
+    "@smithy/util-endpoints": ^2.1.0
+    "@smithy/util-middleware": ^3.0.4
+    "@smithy/util-retry": ^3.0.4
+    "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
-  checksum: aa97aac3407efcd3b72dd3bbd4d38daa158423bce454f93c62fc60b5c9c2cf2077ffe5c58a90d1690559d10731c6dfcac1d9cbcb8286a84d267f2ff7c7d926f4
+  checksum: 90c72041373acbae6bde9132adb80d81d2fe0b466fb495ba4d383c72c7734cfc5d68b7c65c22427820842fed915877ff76b7e54975c3895913e6e2c1d79916ed
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.583.0"
+"@aws-sdk/core@npm:3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/core@npm:3.651.1"
   dependencies:
-    "@aws-sdk/client-sso": 3.583.0
-    "@aws-sdk/token-providers": 3.577.0
-    "@aws-sdk/types": 3.577.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/shared-ini-file-loader": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/core": ^2.4.1
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/signature-v4": ^4.1.1
+    "@smithy/smithy-client": ^3.3.0
+    "@smithy/types": ^3.4.0
+    "@smithy/util-middleware": ^3.0.4
+    fast-xml-parser: 4.4.1
     tslib: ^2.6.2
-  checksum: cd2dd6ae4b0cddcf7fcac507158beeb878db947d37f94a53f0573079fb7d1b817525b0c6ab61e384441a2bd608f8a8a45f7e2476a233b66afc3ae6ad23f72116
+  checksum: 529f147a2a3d0023657a51194e91bfb2dec580a902f0c8a644710bf5110c8ad43bb2c8637ba433e3cbbee459603c718679646cb8d8239815766dbfee7502e302
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.577.0"
+"@aws-sdk/credential-provider-env@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/types": ^3.4.0
+    tslib: ^2.6.2
+  checksum: 85904f366e4de8408af515528e7e7cccf9bd1075bf4556bd7df2e987a8c84d07e6c26a6dac923cd895991f4dbad6987cdefec8812efc5e71b0745feef8fcd4a5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.649.0"
+  dependencies:
+    "@aws-sdk/types": 3.649.0
+    "@smithy/fetch-http-handler": ^3.2.5
+    "@smithy/node-http-handler": ^3.2.0
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/smithy-client": ^3.3.0
+    "@smithy/types": ^3.4.0
+    "@smithy/util-stream": ^3.1.4
+    tslib: ^2.6.2
+  checksum: c376151e2eabf334dc7c9b294fd89fbf6cdeaf929b3d6715be1a83c442ce4e112894778041e74d0cd508e50afc8a176e997487ad0b26b1398f5eeecb5c4c39e1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.651.1"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.649.0
+    "@aws-sdk/credential-provider-http": 3.649.0
+    "@aws-sdk/credential-provider-process": 3.649.0
+    "@aws-sdk/credential-provider-sso": 3.651.1
+    "@aws-sdk/credential-provider-web-identity": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/credential-provider-imds": ^3.2.1
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/shared-ini-file-loader": ^3.1.5
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
   peerDependencies:
-    "@aws-sdk/client-sts": ^3.577.0
-  checksum: d3eb6c99fe2bfae457c8122b155d0608f0cb0c8fd4bc067f587ffced795b61e4709256842ea629abc0849a085b26d1a946711a646dd87394da6b4d31db7f07e6
+    "@aws-sdk/client-sts": ^3.651.1
+  checksum: 7ddab585aabd579058f1d9a6d5b1cd5f5168bffa8f010319cec4eb998e2be11a2e1b775231b0e0e452764b24ea82d38e41706916365477f7e038cfd5037236da
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.577.0"
+"@aws-sdk/credential-provider-node@npm:3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/credential-provider-node@npm:3.651.1"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/credential-provider-env": 3.649.0
+    "@aws-sdk/credential-provider-http": 3.649.0
+    "@aws-sdk/credential-provider-ini": 3.651.1
+    "@aws-sdk/credential-provider-process": 3.649.0
+    "@aws-sdk/credential-provider-sso": 3.651.1
+    "@aws-sdk/credential-provider-web-identity": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/credential-provider-imds": ^3.2.1
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/shared-ini-file-loader": ^3.1.5
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
-  checksum: f325612558d8d56a13e0593a78a1807c55dac5913313ed53d0a09a1c4bc771976e74e1738bd46068adeea755c35f72b19c2f902ecad1ff1ae52290972cf9fe88
+  checksum: 7c0cd5283f4d2005402f263872846ce9f30bb9aadae8508990e3f19321477d7965a16111c7ec01a3532dd7bd73c2ba5703691db3de11c1ccfcdefe54f6fe084d
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.577.0"
+"@aws-sdk/credential-provider-process@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/shared-ini-file-loader": ^3.1.5
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
-  checksum: 142e993c82997391fb9c66244f2add15ad71e626b9aacf36a81ea369d33e3a1375ece09dd6315bf8fcaf4d8dcbaae340237088f1091f12a8f56740eddb32090a
+  checksum: 5cb86e927aaa01df435635a74f73657a363dfaa86aaf2149ac08d35682613e62c9c6485b5855f2230e5978f98e8ac430fc7c325027211f986af9cdfef3a2aff6
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.577.0"
+"@aws-sdk/credential-provider-sso@npm:3.651.1":
+  version: 3.651.1
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.651.1"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/client-sso": 3.651.1
+    "@aws-sdk/token-providers": 3.649.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/shared-ini-file-loader": ^3.1.5
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
-  checksum: 9655fe7b9a071a9a62397871a7bc529ebfff372a2cd1997b78c22ff320b0cdf0224881c122375e0b97e7307a167d437f438f6c414db71c882afb66a0510a519e
+  checksum: 0ec5e0dbd5d4353412777f73e9dff9399efaaaab951b032366f1c48ca228540ad3deee3dac45ec43c3c74e67cc12149777f56031573233cfa6c3612ebb2f3a3e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.583.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@aws-sdk/util-endpoints": 3.583.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
-  checksum: a704418bb5ba6414345cc0d5464b2554d4ac8efdd9e0cb747a7514673bb687500119c77f9109f4b04975095b72b7be64051dbf5e627975950f37c9e53df0fe5b
+  peerDependencies:
+    "@aws-sdk/client-sts": ^3.649.0
+  checksum: 8df15387ce851f2d4a54c63c7e98d9f401c0b406cd9e35a58461bbb00842ae46e8074e93b4bee39793a61bfd46a01d78e3fcfffa56a60c898a0d880a36e2628f
   languageName: node
   linkType: hard
 
-"@aws-sdk/region-config-resolver@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/region-config-resolver@npm:3.577.0"
+"@aws-sdk/middleware-host-header@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/types": ^3.4.0
+    tslib: ^2.6.2
+  checksum: e6ace87d76c91750489241d9f0c22070e9ddcecdf5d09ca958923269b60155502690af472e5c00d565cde83fec1d5fab780cc735d62773e874d8f6980d620dce
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.649.0"
+  dependencies:
+    "@aws-sdk/types": 3.649.0
+    "@smithy/types": ^3.4.0
+    tslib: ^2.6.2
+  checksum: 967e239cc6d8d969a0d6087c8070d6d6a66b78c79930b9963a53ed2a578955478328369a3eadb978cb9432c6c58db5972b4d3ea9ff6ece71950a5f115ff50de7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.649.0"
+  dependencies:
+    "@aws-sdk/types": 3.649.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/types": ^3.4.0
+    tslib: ^2.6.2
+  checksum: 0be3b9c23b002ced7f851e22e02832300756a83902b22851eed2e85d336fcda05af92d52eaf31bf566330e2c7bb725945b41293f84761bcc263946a5f776a8e6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.649.0"
+  dependencies:
+    "@aws-sdk/types": 3.649.0
+    "@aws-sdk/util-endpoints": 3.649.0
+    "@smithy/protocol-http": ^4.1.1
+    "@smithy/types": ^3.4.0
+    tslib: ^2.6.2
+  checksum: 01e00cd7e7a1f906c44b4abbda88898d775fd1493331ecba6dc6de73c5146f9bcbf9d37f212cce4b2f56aac37b270ed34cf56190e6c52cf59da772b2ac2aa48b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.649.0"
+  dependencies:
+    "@aws-sdk/types": 3.649.0
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/types": ^3.4.0
     "@smithy/util-config-provider": ^3.0.0
-    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-middleware": ^3.0.4
     tslib: ^2.6.2
-  checksum: 66326254108ca87300bbb7aea7786da617293bb7fe093153eab123ff73a824071b1d3a155827bb9193925704e4f60d01cddfc71018d2e1a82d7609091338acfe
+  checksum: fcd8ae56985b1ac31308a0402492b31510ba9e0889b46d64bcc42c9c00665abc295b7ff85db8050ac4751f11c7a229bc6990e56b8ae0ee7474d53f3f75832ecf
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/token-providers@npm:3.577.0"
+"@aws-sdk/token-providers@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/token-providers@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/shared-ini-file-loader": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/property-provider": ^3.1.4
+    "@smithy/shared-ini-file-loader": ^3.1.5
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
   peerDependencies:
-    "@aws-sdk/client-sso-oidc": ^3.577.0
-  checksum: e0437ed4af6d1b78d457a7c8abc8367e3c9134c678e945af776d3882175b6b0e73cfd9a49493da4e689aea51dd654ea58ab22fb88a336bb0cd29310dea4c90f2
+    "@aws-sdk/client-sso-oidc": ^3.649.0
+  checksum: 388cf0efd5a2915128187824bac33ff791bc8146b0ca3c16d23fbb424221c0fe7f5a53ef1e8b8c038ad8a727a7e4db189c99be652332efb8d43cd2495de7a37e
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/types@npm:3.577.0"
+"@aws-sdk/types@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/types@npm:3.649.0"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
-  checksum: d10fe1d720adf3d8b17d5c23787611e336509569df7526efa96e8901100b9279a68e30a207eff60dc5cfa011abd68d47b81e40f2d4d1a9ddfd2d3653c20e1734
+  checksum: d8a7ee318474a9e918cbc56ec25e9fb3518bb5f559c785986a8f336b672fa49b259386522d1b2ca828de464b0bb3744bade98e9e75183daa2e762e52d835b4b3
   languageName: node
   linkType: hard
 
@@ -685,15 +680,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.583.0":
-  version: 3.583.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.583.0"
+"@aws-sdk/util-endpoints@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/types": ^3.0.0
-    "@smithy/util-endpoints": ^2.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/types": ^3.4.0
+    "@smithy/util-endpoints": ^2.1.0
     tslib: ^2.6.2
-  checksum: 8494b939f43f18ea286083b5a8d2c8aeba65361f922066b195400f43ea5b165438d0fe3f6064a7d5a21c980adf84d702da42ba733fc41f9374c36e3ef277c408
+  checksum: 8b87f828dc62aa95d4d31b9e6ec55a7feb0e61132021eb02f7ce0e7f6192b4f57f6e1516ea445eaa6839088b1955cda96042a0551390c804773fdc1a1139318e
   languageName: node
   linkType: hard
 
@@ -706,41 +701,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.577.0"
+"@aws-sdk/util-user-agent-browser@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/types": ^3.4.0
     bowser: ^2.11.0
     tslib: ^2.6.2
-  checksum: 48b29b186f9d59c7ee272568cb0752834527aeccf122e4794313f84fb4c72dc65edf4bbf22f07aa7e2dde7da288e6d7ba20633edd9dbc853aca1b170bdfe1532
+  checksum: e4b3b36b6bcf9e6362e0293ce3e6164d251c9d0bdf2cab43853d22e994f3bfab183fa6478fe8b02334886e071c70b17dd4f59a5ae30cf7f33d6def67cae22456
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.577.0":
-  version: 3.577.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.577.0"
+"@aws-sdk/util-user-agent-node@npm:3.649.0":
+  version: 3.649.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.649.0"
   dependencies:
-    "@aws-sdk/types": 3.577.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@aws-sdk/types": 3.649.0
+    "@smithy/node-config-provider": ^3.1.5
+    "@smithy/types": ^3.4.0
     tslib: ^2.6.2
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 732fb562a02826fbe0e0ce2571c4f396b14515a57f01121e99b84088761f1cf6e47e03c9a3613e51f3ff34aae8eae3b47440e0e012a9f54096e7f2b244705ef5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-browser@npm:^3.0.0":
-  version: 3.188.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.188.0"
-  dependencies:
-    tslib: ^2.3.1
-  checksum: dacd27164aa0835888434e080b67f04510e2281560540ff73496f2d0aa73b0b7f830ec08491b35c3a51bf6214615579182aff8727e151e54a74a97a197a2ac31
+  checksum: 1b0c475b1bdff3e8a0d1ae3c2f181477804b30a6018d980019d890db15b223a293316e93d5233c6ca6628aba80aeb2f92474b81630fd1401a8bffd9307db57d7
   languageName: node
   linkType: hard
 
@@ -2560,90 +2546,101 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/abort-controller@npm:3.0.0"
+"@smithy/abort-controller@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "@smithy/abort-controller@npm:3.1.4"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 8ad1551b558d5cb14e60fdaf07663d37828d11e9bb0faccfa3622ee0b0ddd7c7eab97ae36f501fd3d5bdcb9c570ed4e9ed84cb7b4490053900d20399297f95b5
+  checksum: 7fbf773a29ec160b6d230d95454f904a84c263e33421a7fb094abd2e04ef6d7286a1d938388eac01de0ba6085ef0770191b2ab776e024073e5eddf963c7ec65a
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/config-resolver@npm:3.0.0"
+"@smithy/config-resolver@npm:^3.0.6, @smithy/config-resolver@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@smithy/config-resolver@npm:3.0.8"
   dependencies:
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/node-config-provider": ^3.1.7
+    "@smithy/types": ^3.4.2
     "@smithy/util-config-provider": ^3.0.0
-    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-middleware": ^3.0.6
     tslib: ^2.6.2
-  checksum: 66d66e0c054e90e8dec61d1f8f774709f0e3d5227cec30221c27cc21fb51bbd691c0281f8f01bc4cc0a3472cb7776db3544260a45f8104b0ba1493c27ff2794b
+  checksum: 23571e36a04ac1369f96401f8f88e0bf0867bd31899370168502c084342da3aa4604c6edc09e252599cb7b4cbefc2b731ee40025cf3ba7c4583a3d5fefd71b40
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@smithy/core@npm:2.0.1"
+"@smithy/core@npm:^2.4.1":
+  version: 2.4.3
+  resolution: "@smithy/core@npm:2.4.3"
   dependencies:
-    "@smithy/middleware-endpoint": ^3.0.0
-    "@smithy/middleware-retry": ^3.0.1
-    "@smithy/middleware-serde": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/util-middleware": ^3.0.0
+    "@smithy/middleware-endpoint": ^3.1.3
+    "@smithy/middleware-retry": ^3.0.18
+    "@smithy/middleware-serde": ^3.0.6
+    "@smithy/protocol-http": ^4.1.3
+    "@smithy/smithy-client": ^3.3.2
+    "@smithy/types": ^3.4.2
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-middleware": ^3.0.6
+    "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
-  checksum: 6a02cfc67ea6f7eac367c41c7200c604bbd087a02c418aa69e1cc833b4f0693b1e28205eb62f516ca62ad4cac851a06f435ceaa4505f73b44f89790c11a1e889
+  checksum: 7f7c8857632b44b8e8d6b84a944d976c678b69e1b01de9e0b6da6a468da502ad73cb01a75f6164c481a94439314217ba818ec981cc15912b3390e2ba5f9fb6d5
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/credential-provider-imds@npm:3.0.0"
+"@smithy/credential-provider-imds@npm:^3.2.1, @smithy/credential-provider-imds@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "@smithy/credential-provider-imds@npm:3.2.3"
   dependencies:
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/types": ^3.0.0
-    "@smithy/url-parser": ^3.0.0
+    "@smithy/node-config-provider": ^3.1.7
+    "@smithy/property-provider": ^3.1.6
+    "@smithy/types": ^3.4.2
+    "@smithy/url-parser": ^3.0.6
     tslib: ^2.6.2
-  checksum: f592303f6247ae3f404cc6dce108c69f88ffcc56d11fc219e16d101ec58b00141d6253c3f0bedb4a6cf4de5df9cea29514851647aa1a9d0ebe5865fdce37a7ca
+  checksum: 23aff4f9f671fe5a25c911a98d66489f6ea27cb4a39c3cab3d1d20bb85b50200a18e5a1923983f03b5c9ac551ed402002a1348016ed28def2185a1e4ac6c311e
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@smithy/fetch-http-handler@npm:3.0.1"
+"@smithy/fetch-http-handler@npm:^3.2.5, @smithy/fetch-http-handler@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "@smithy/fetch-http-handler@npm:3.2.7"
   dependencies:
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/querystring-builder": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/protocol-http": ^4.1.3
+    "@smithy/querystring-builder": ^3.0.6
+    "@smithy/types": ^3.4.2
     "@smithy/util-base64": ^3.0.0
     tslib: ^2.6.2
-  checksum: ddb6e1ad989f5f02e7af7ea17a2f8e742f99e53358d64c57803a4fa9dd12e2a4a1c5c5ff69e912937bed661a6a4c583eb184c5e159be720170b686d66647dd01
+  checksum: b54e9e60a4b73d768f8afae8bd327e4b2d05f9042b1dc2b52acaf7e3202a77127737693ff961795c106bc8c707ecf466a85d7fb99c8cb9ce3e0315651dd59cc8
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/hash-node@npm:3.0.0"
+"@smithy/hash-node@npm:^3.0.4":
+  version: 3.0.6
+  resolution: "@smithy/hash-node@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     "@smithy/util-buffer-from": ^3.0.0
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
-  checksum: ef2520c1e5c7dc7669a2870881edaa9fac07e2bffa300d2434d599453dbce1b0c5239de6fb6d55f121a467e144a1f5c6d7f8d1ddf4547ce86d3e81827289752d
+  checksum: afd8335df075237f2e92c1b1da05eaa85cac6f08d0b6532aeba6c00e629d0ac089b10ca26ad89993310379f2602068bf147ae8708f4bab9d02aebaa9d3b612bd
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/invalid-dependency@npm:3.0.0"
+"@smithy/invalid-dependency@npm:^3.0.4":
+  version: 3.0.6
+  resolution: "@smithy/invalid-dependency@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 3227d5d8ba49d6ca09f95215614d41b75a717985ac2f5c4caa5c082dc87e1a510e1d1af738fe27cdb93c8425a189b2ec74a7d57d949cefa8cbcd62ed83ceb798
+  checksum: 2581cf77bc5e26e66617c26fd4edc298722791c3a1b65a79c6547834e695e533a57c3fe6a306c3ee054c02ef3482014dfb3e715ba87714b107e9c0c3b9a6ef48
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/is-array-buffer@npm:2.2.0"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: cd12c2e27884fec89ca8966d33c9dc34d3234efe89b33a9b309c61ebcde463e6f15f6a02d31d4fddbfd6e5904743524ca5b95021b517b98fe10957c2da0cd5fc
   languageName: node
   linkType: hard
 
@@ -2656,180 +2653,181 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/middleware-content-length@npm:3.0.0"
+"@smithy/middleware-content-length@npm:^3.0.6":
+  version: 3.0.8
+  resolution: "@smithy/middleware-content-length@npm:3.0.8"
   dependencies:
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/protocol-http": ^4.1.3
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 658474b9c10696f701ae32a741c357192d4e8e1f409855093a3660fa21d4785972f2ec1c6973d159a875437a414c4f6e64b2fd0e12a7242cb5d73679b3283667
+  checksum: 292310d3d6ed5639e24705283d94e6d5b800214b310b3d34617d2b94394846fde9e8312f661b38e0d7769314071f124826ceaf3202f345d32fc017c1d2b31665
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/middleware-endpoint@npm:3.0.0"
+"@smithy/middleware-endpoint@npm:^3.1.1, @smithy/middleware-endpoint@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "@smithy/middleware-endpoint@npm:3.1.3"
   dependencies:
-    "@smithy/middleware-serde": ^3.0.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/shared-ini-file-loader": ^3.0.0
-    "@smithy/types": ^3.0.0
-    "@smithy/url-parser": ^3.0.0
-    "@smithy/util-middleware": ^3.0.0
+    "@smithy/middleware-serde": ^3.0.6
+    "@smithy/node-config-provider": ^3.1.7
+    "@smithy/shared-ini-file-loader": ^3.1.7
+    "@smithy/types": ^3.4.2
+    "@smithy/url-parser": ^3.0.6
+    "@smithy/util-middleware": ^3.0.6
     tslib: ^2.6.2
-  checksum: a1be07b91f4ddcd6b5358bb8b43529756a80aefb451bd95b2d69e5743229ad7c8d55eed0ad73225301b833dd05173760fa0453891640d4407b4d8f4006c566f5
+  checksum: c3f4fcffa0ee0da9def2270d4dd5d84342edfebaec2ed1ffbbc9dec9615a01180d269ff9bb9cec72269707e2c44a53e7180e42802e1ea31e4b85ef763a577c66
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@smithy/middleware-retry@npm:3.0.1"
+"@smithy/middleware-retry@npm:^3.0.16, @smithy/middleware-retry@npm:^3.0.18":
+  version: 3.0.18
+  resolution: "@smithy/middleware-retry@npm:3.0.18"
   dependencies:
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/service-error-classification": ^3.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
-    "@smithy/util-middleware": ^3.0.0
-    "@smithy/util-retry": ^3.0.0
+    "@smithy/node-config-provider": ^3.1.7
+    "@smithy/protocol-http": ^4.1.3
+    "@smithy/service-error-classification": ^3.0.6
+    "@smithy/smithy-client": ^3.3.2
+    "@smithy/types": ^3.4.2
+    "@smithy/util-middleware": ^3.0.6
+    "@smithy/util-retry": ^3.0.6
     tslib: ^2.6.2
     uuid: ^9.0.1
-  checksum: 33b1c5173ccbcbfd8127ef6009ec167d80fbd539cad35372b25a05b75b1a3b999bba39a3327a46916f41512d8ee4d3d6cfd56bbfdc36867118bee9cac4d94ab3
+  checksum: 8561ed11d073579603fa3f8d6fbb63048831b948f804edcae48c3382df61f975580d13ef8ba4777bed05b28031319fdafc4d5c7676dc5a98955bedf073743489
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/middleware-serde@npm:3.0.0"
+"@smithy/middleware-serde@npm:^3.0.4, @smithy/middleware-serde@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/middleware-serde@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 9520948ab8fbe50f17eb4fdc2065a068cc9b954c876c354c355cd729ad29790815c4acd4fdafe32456e81308ec2266d35e82aa69fedbcb0cad1981785fc87c25
+  checksum: a16b4ebec9262ca82b89467d8400d3b0940bc1f7504f60f7e6cad9baa3e41b48327b8d628286af59314c7622760aee9099878c142f9f456c585da8d59da6bd32
   languageName: node
   linkType: hard
 
-"@smithy/middleware-stack@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/middleware-stack@npm:3.0.0"
+"@smithy/middleware-stack@npm:^3.0.4, @smithy/middleware-stack@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/middleware-stack@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: ca2e9e41aa78dc0e50b51cf94ff3d85ee86a0e241dde5f41640bf4401b862519ba52824c2ad04d861f6e9325749bacfd5ff4be0fef67c8b6f084c9935cce57ca
+  checksum: 5851dcf20eebe391e61f741570e78ccd2fe281acd6b34e54fd3f4bc4d6714cc80d0bd6ec6cea092f674e5e1eecb66b0e88ecec1aa3b19dfa5dba177944aa3f2a
   languageName: node
   linkType: hard
 
-"@smithy/node-config-provider@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/node-config-provider@npm:3.0.0"
+"@smithy/node-config-provider@npm:^3.1.5, @smithy/node-config-provider@npm:^3.1.7":
+  version: 3.1.7
+  resolution: "@smithy/node-config-provider@npm:3.1.7"
   dependencies:
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/shared-ini-file-loader": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/property-provider": ^3.1.6
+    "@smithy/shared-ini-file-loader": ^3.1.7
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 2c2de21e40bcaf85faa27fe856d0c61257fd05c6b205eb7799a26cf1bea7c25023f7951b0b48730c8b77569a3a762ddaa462c5eca193ae051431ebd553c1e637
+  checksum: 4bf1e1322c6a68e26fc426016ba2308e0416d8efeebd8473a694f263a91fdc57954b45406a022d6653f6016ce0d5533bdfa44184f759efb8ea4f3bc1e707f186
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/node-http-handler@npm:3.0.0"
+"@smithy/node-http-handler@npm:^3.2.0, @smithy/node-http-handler@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@smithy/node-http-handler@npm:3.2.2"
   dependencies:
-    "@smithy/abort-controller": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/querystring-builder": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/abort-controller": ^3.1.4
+    "@smithy/protocol-http": ^4.1.3
+    "@smithy/querystring-builder": ^3.0.6
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 194542f2abbc1f1ccd9655eb4d06b2fead212e71954d20ca429904dfd7c49f2ea13c06604c31cd7700af53971d86534ec9e0b53c16479dc1491569a99aee67d7
+  checksum: 2ccae7bba714e7831e5f1436106e5b1a1ea41f6b7d52868246d566b5f88a63efde6be52c424ff29993acd2f1f9ea3881b97450b0b05042251ec3ec53483f68fc
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/property-provider@npm:3.0.0"
+"@smithy/property-provider@npm:^3.1.4, @smithy/property-provider@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "@smithy/property-provider@npm:3.1.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 741cb59b7eab30910a2e38bee1c489120d6b6ef4b3682d556abcf9ddf545a9249902281d72f4a0282953e6f2ec9b6aa0bac8e5003cb0ff389475b4c793ac83e1
+  checksum: b8e3f06a01a5833ab7204fde1701fc2fa92737c2205daa7defab43505cc50928dd71eadca359f04f85be49f913efc8c57222899f7861ae95f9e778db84ff3d90
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/protocol-http@npm:4.0.0"
+"@smithy/protocol-http@npm:^4.1.1, @smithy/protocol-http@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@smithy/protocol-http@npm:4.1.3"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 0cea8e4933b1ca888f755495ac10cec9191678eb3425b755443479a1653223eede0d031a3b4cc04a34b80c4ed7b06d7e0a576f577988d876b81982aa84e31bfc
+  checksum: 885b077e3ac70d323b139c86938d145d9c38e67336d0ca0e7f2ed650de7ed6224d900a69d38eab8675161eae5773a8e09df799dedc856a2636bf71cfb1b42a33
   languageName: node
   linkType: hard
 
-"@smithy/querystring-builder@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/querystring-builder@npm:3.0.0"
+"@smithy/querystring-builder@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/querystring-builder@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     "@smithy/util-uri-escape": ^3.0.0
     tslib: ^2.6.2
-  checksum: 28a8a243002560f0928bf73b4686a0f81ed867957a033c2fc9fb249fb7006f076e78fcb506c96956e9d1d5e34a4c6228d0aeb7fcdc9418cdfe3377084e0654f4
+  checksum: a6a3fc016606e4eb491c37fdf97b4c2f7bf090cc994535bc3cc94d50ab4931771f11078aa70f1b83bf4151cd9e6de7f1f76ec19315af56a664c8b8197f727b43
   languageName: node
   linkType: hard
 
-"@smithy/querystring-parser@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/querystring-parser@npm:3.0.0"
+"@smithy/querystring-parser@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/querystring-parser@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 5b76846e1ef0e19d4cd249089184597476b2f82ff491952b7f61d0dc8705b8596f9d8579fe3c2ce6b61dff61271990c35c85c89aba3724e781b4993afc816a2a
+  checksum: afa89d43e01a21375a8958a66e68857fc878264a847da486660875aecb804f642c0b74aa6641d404d0c5361ed58cf98de5b5acd20df425dfd17475ec6f061722
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/service-error-classification@npm:3.0.0"
+"@smithy/service-error-classification@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/service-error-classification@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
-  checksum: 44ad8cd553896c8608d411763d962f5a758bc86fc49f58ef70b2d2a26f5a9189d1bfa0eed13cfe457cf7bfbedcb2c3e4b6e77bd93bb534f6bef6da74ab776807
+    "@smithy/types": ^3.4.2
+  checksum: 16b9a181c250064c1ca795575cd8a0a476cbca83594b4939890092cb74f768180d4b54d4293071c942d251f2f88990ee4e380c522b72358f211467845087daf9
   languageName: node
   linkType: hard
 
-"@smithy/shared-ini-file-loader@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/shared-ini-file-loader@npm:3.0.0"
+"@smithy/shared-ini-file-loader@npm:^3.1.5, @smithy/shared-ini-file-loader@npm:^3.1.7":
+  version: 3.1.7
+  resolution: "@smithy/shared-ini-file-loader@npm:3.1.7"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: d8f0d6e8f30293adc7ad0f3877d37c827e04abbcee70750b6f25be0f6fc2b80b659beadb35562f6d2312d5b437cb801241c3c5610986228b83ca3a5c2c1071dd
+  checksum: 2e222de3bb4693db441dd84b5a3fadfbe4f08eb978df1131e5701657214b3104c811f69d0a7157b39c77d8d80c8a368b97343c68cb81adea8877bc452de5c4a6
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/signature-v4@npm:3.0.0"
+"@smithy/signature-v4@npm:^4.1.1":
+  version: 4.1.3
+  resolution: "@smithy/signature-v4@npm:4.1.3"
   dependencies:
     "@smithy/is-array-buffer": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/protocol-http": ^4.1.3
+    "@smithy/types": ^3.4.2
     "@smithy/util-hex-encoding": ^3.0.0
-    "@smithy/util-middleware": ^3.0.0
+    "@smithy/util-middleware": ^3.0.6
     "@smithy/util-uri-escape": ^3.0.0
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
-  checksum: 18962f427e33843014e7886bb5b8c3164150a87c5c604f48e6a080017d12f04fd55b1a7776f0f438cc641a2472b75d98c7173a34b9335dcd6a89c55fc1c65dd4
+  checksum: a542dbdea4d04be53b424658f7372fedf1810520be6f8595e0692f5164f8e35554e3a065befd211de4ac99b56bcc6b03460c4bd2dd1fef31468b0971539d4c0c
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@smithy/smithy-client@npm:3.0.1"
+"@smithy/smithy-client@npm:^3.3.0, @smithy/smithy-client@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "@smithy/smithy-client@npm:3.3.2"
   dependencies:
-    "@smithy/middleware-endpoint": ^3.0.0
-    "@smithy/middleware-stack": ^3.0.0
-    "@smithy/protocol-http": ^4.0.0
-    "@smithy/types": ^3.0.0
-    "@smithy/util-stream": ^3.0.1
+    "@smithy/middleware-endpoint": ^3.1.3
+    "@smithy/middleware-stack": ^3.0.6
+    "@smithy/protocol-http": ^4.1.3
+    "@smithy/types": ^3.4.2
+    "@smithy/util-stream": ^3.1.6
     tslib: ^2.6.2
-  checksum: 901107c8bc7b80e0e1798210f996a30a9af441a48d399bbc89ed94790a3d2d93263896f71d2139c9ab4d2f40e5e752d233abad45621e33ba2eed8e390f38c364
+  checksum: 58725fc69f9efb6dbe0c5f8449ac0b6fcd26a6bbecb4bdaca4446f6cebb1ca30e651d9bcab9f1cfa4eb3c3b618eb115955aacef4f2d0e6c32e7c1d5d63dba06a
   languageName: node
   linkType: hard
 
@@ -2842,23 +2840,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/types@npm:3.0.0"
+"@smithy/types@npm:^3.4.0, @smithy/types@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "@smithy/types@npm:3.4.2"
   dependencies:
     tslib: ^2.6.2
-  checksum: 1c9c196c781aec0bed7c1519f91030ca4301f30f969394b099ccaa6ab0b47e55b211f54ae56a5a101e91d64899f147d49861e77c24fdc56117cf191a300e00ec
+  checksum: 84daaa72d890a977185fa34566879ba3ee6cab6d32986dfa773c540b6dee81701128067ed0fe876d9f2dd197e4079d66ec32bdd0b52c18e9a9b0c493bc1a7478
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/url-parser@npm:3.0.0"
+"@smithy/url-parser@npm:^3.0.4, @smithy/url-parser@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/url-parser@npm:3.0.6"
   dependencies:
-    "@smithy/querystring-parser": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/querystring-parser": ^3.0.6
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: dd92f24432b90cdd4aa80b3b3cd7f5075a54248756f87e4961cb1d7c52483cee44b3f98c96fefd01e8cc5bd2744e7d658ec547cdb6cdc7365f46c0f7df2b3eb2
+  checksum: 861000a437bc81cc9d09ca272458fdd2934d6d9fbdff238e672783435ce9b1c46cc9cd4f9f037e2f9950f4e8123dc6b23f6d73a62d3789bee163db5ee176b484
   languageName: node
   linkType: hard
 
@@ -2891,6 +2889,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-buffer-from@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/util-buffer-from@npm:2.2.0"
+  dependencies:
+    "@smithy/is-array-buffer": ^2.2.0
+    tslib: ^2.6.2
+  checksum: 424c5b7368ae5880a8f2732e298d17879a19ca925f24ca45e1c6c005f717bb15b76eb28174d308d81631ad457ea0088aab0fd3255dd42f45a535c81944ad64d3
+  languageName: node
+  linkType: hard
+
 "@smithy/util-buffer-from@npm:^3.0.0":
   version: 3.0.0
   resolution: "@smithy/util-buffer-from@npm:3.0.0"
@@ -2910,42 +2918,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@smithy/util-defaults-mode-browser@npm:3.0.1"
+"@smithy/util-defaults-mode-browser@npm:^3.0.16":
+  version: 3.0.18
+  resolution: "@smithy/util-defaults-mode-browser@npm:3.0.18"
   dependencies:
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
+    "@smithy/property-provider": ^3.1.6
+    "@smithy/smithy-client": ^3.3.2
+    "@smithy/types": ^3.4.2
     bowser: ^2.11.0
     tslib: ^2.6.2
-  checksum: eaf4389187d4c2e7f77010fceb4b10c3e396654d634ff1ef5c66164e86049000fe30eca010f637824ab88b7a9e501fcd08cab7a8b523468af6735b397e481e9a
+  checksum: f5bd83ad958b3cbd288f59963cda095a014e6d7ea717222548147c3bfcf27679dcff81203472d61b757c75e0dfdf98d67e8d088901a702bbdd13c5563ccc9abf
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@smithy/util-defaults-mode-node@npm:3.0.1"
+"@smithy/util-defaults-mode-node@npm:^3.0.16":
+  version: 3.0.18
+  resolution: "@smithy/util-defaults-mode-node@npm:3.0.18"
   dependencies:
-    "@smithy/config-resolver": ^3.0.0
-    "@smithy/credential-provider-imds": ^3.0.0
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/property-provider": ^3.0.0
-    "@smithy/smithy-client": ^3.0.1
-    "@smithy/types": ^3.0.0
+    "@smithy/config-resolver": ^3.0.8
+    "@smithy/credential-provider-imds": ^3.2.3
+    "@smithy/node-config-provider": ^3.1.7
+    "@smithy/property-provider": ^3.1.6
+    "@smithy/smithy-client": ^3.3.2
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 2355a03b69f56d34e19653597fda1df5e598a04a5c9139a1902dd658b4d883a7c24b04f0e038043daa874f02f7ead719ce2ef2c1d0f9d83bc02a8ea120357469
+  checksum: 86917bf7d46826ff859ee656e88c00c7ab15ef977a7aacaa7906075d17039914b1219c6cd3428c2b3273b9378191d414f64137be3606357871294519f0c6fa5f
   languageName: node
   linkType: hard
 
-"@smithy/util-endpoints@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-endpoints@npm:2.0.0"
+"@smithy/util-endpoints@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "@smithy/util-endpoints@npm:2.1.2"
   dependencies:
-    "@smithy/node-config-provider": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/node-config-provider": ^3.1.7
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 0c4d33ace7bf3d76b6e563f2a07e43a49d6a367d7874dcfc7f06c97accc5307f5e881aea7ea782f3a05e5ddf9e1e2e238070d563496423c048d115f539fc9941
+  checksum: b769e64828b9aa3f9e327514cfd35a62584fcc363092173f7f4c55a602c5e5aba342616d6816a2045d334797ffe26086534b627d6e007d4bd4a54358c7ed4a8d
   languageName: node
   linkType: hard
 
@@ -2958,40 +2966,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/util-middleware@npm:3.0.0"
+"@smithy/util-middleware@npm:^3.0.4, @smithy/util-middleware@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/util-middleware@npm:3.0.6"
   dependencies:
-    "@smithy/types": ^3.0.0
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: ab73eb58942733f832a730b4ed29013eb2c1ea04b6d108b82aee92b832ba2c1e73f78dcbf7aaeab9403583b92f85b7dbc7b33d22d1d37f0900a814bfdea19cc9
+  checksum: d51a473bd376aef6e26b1e26ced37350464058661fb685addf84babbe14f5225734470cdf47a80e478c679d6e984fbdaf9af70c9ff66578e180af9f7f81e5c35
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/util-retry@npm:3.0.0"
+"@smithy/util-retry@npm:^3.0.4, @smithy/util-retry@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/util-retry@npm:3.0.6"
   dependencies:
-    "@smithy/service-error-classification": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/service-error-classification": ^3.0.6
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 699fb2da6d97e903b9aec3883fd9f8e3477a03d377705840ca9bf12b440d803db89742bc8cf239448287b0369672dd6076afd3e663322106302217623a76d855
+  checksum: 3bd5ddabf8f856343a5da2375425ff71ae8739b43f21e22ca9d910506fb4e35fa4c43d3a0fa6afbe47b5619624d4c4736806df246168a6fae1bf748862483f2f
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@smithy/util-stream@npm:3.0.1"
+"@smithy/util-stream@npm:^3.1.4, @smithy/util-stream@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "@smithy/util-stream@npm:3.1.6"
   dependencies:
-    "@smithy/fetch-http-handler": ^3.0.1
-    "@smithy/node-http-handler": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/fetch-http-handler": ^3.2.7
+    "@smithy/node-http-handler": ^3.2.2
+    "@smithy/types": ^3.4.2
     "@smithy/util-base64": ^3.0.0
     "@smithy/util-buffer-from": ^3.0.0
     "@smithy/util-hex-encoding": ^3.0.0
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
-  checksum: 1b691d77470722d2a29e5294f2802161ef54d45ded78d27c0d53f9bb84051407673579cf70f9c6e810e419d2ba8446acd17e1dde60f219a6df3b8d66476b0071
+  checksum: 84cbcbd1febedb5e04267288128eb45a4f68e33397b3a1d8cb65fb03d9104b150e6ac7bf5ca4c9b6a9376e9376f7247b3c0446803386e8b31b8311cee5db0b70
   languageName: node
   linkType: hard
 
@@ -3001,6 +3009,16 @@ __metadata:
   dependencies:
     tslib: ^2.6.2
   checksum: d7ee01c978e2b08d0a89a3b678f5d5e5d5bb4ab4ab85567a238b1a6195dff1bdaf9ae62497e7f32ff5121b3dc007c370bcb6e8ef79b01fe5acdec5bbce8c7ce4
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@smithy/util-utf8@npm:2.3.0"
+  dependencies:
+    "@smithy/util-buffer-from": ^2.2.0
+    tslib: ^2.6.2
+  checksum: 00e55d4b4e37d48be0eef3599082402b933c52a1407fed7e8e8ad76d94d81a0b30b8bfaf2047c59d9c3af31e5f20e7a8c959cb7ae270f894255e05a2229964f0
   languageName: node
   linkType: hard
 
@@ -3014,14 +3032,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@smithy/util-waiter@npm:3.0.0"
+"@smithy/util-waiter@npm:^3.1.3":
+  version: 3.1.5
+  resolution: "@smithy/util-waiter@npm:3.1.5"
   dependencies:
-    "@smithy/abort-controller": ^3.0.0
-    "@smithy/types": ^3.0.0
+    "@smithy/abort-controller": ^3.1.4
+    "@smithy/types": ^3.4.2
     tslib: ^2.6.2
-  checksum: 9e6aba7175abf6f96b2a15ece6ca1eb3a218bb494df0bb3a14c3e9bc59caf078ba5fe48e3a073d3f20ee65cb483f3b12e56808bfe1f094e28a21a3eceadfd045
+  checksum: aa2dedcd9be3c6c2a56cba24c3586af63ff2b9f0aab0ba8054fa7cc3bbf1553a7346c2e464743580e93f740d7ccbc9f254728f7d67ea3b110fce78a74fe7b85a
   languageName: node
   linkType: hard
 
@@ -4211,8 +4229,8 @@ __metadata:
   resolution: "docker-login@workspace:."
   dependencies:
     "@actions/core": ^1.10.1
-    "@aws-sdk/client-ecr": ^3.583.0
-    "@aws-sdk/client-ecr-public": ^3.583.0
+    "@aws-sdk/client-ecr": ^3.651.1
+    "@aws-sdk/client-ecr-public": ^3.651.1
     "@docker/actions-toolkit": ^0.35.0
     "@types/node": ^20.12.12
     "@typescript-eslint/eslint-plugin": ^7.9.0
@@ -4663,14 +4681,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:4.2.5":
-  version: 4.2.5
-  resolution: "fast-xml-parser@npm:4.2.5"
+"fast-xml-parser@npm:4.4.1":
+  version: 4.4.1
+  resolution: "fast-xml-parser@npm:4.4.1"
   dependencies:
     strnum: ^1.0.5
   bin:
     fxparser: src/cli/cli.js
-  checksum: d32b22005504eeb207249bf40dc82d0994b5bb9ca9dcc731d335a1f425e47fe085b3cace3cf9d32172dd1a5544193c49e8615ca95b4bf95a4a4920a226b06d80
+  checksum: f440c01cd141b98789ae777503bcb6727393296094cc82924ae9f88a5b971baa4eec7e65306c7e07746534caa661fc83694ff437d9012dc84dee39dfbfaab947
   languageName: node
   linkType: hard
 
@@ -7497,14 +7515,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.11.1":
+"tslib@npm:^1.10.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.5.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.3, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
…ith 2 updates

Bumps the aws-sdk-dependencies group with 2 updates in the / directory: [@aws-sdk/client-ecr](https://github.com/aws/aws-sdk-js-v3/tree/HEAD/clients/client-ecr) and [@aws-sdk/client-ecr-public](https://github.com/aws/aws-sdk-js-v3/tree/HEAD/clients/client-ecr-public).


Updates `@aws-sdk/client-ecr` from 3.583.0 to 3.651.1
- [Release notes](https://github.com/aws/aws-sdk-js-v3/releases)
- [Changelog](https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-ecr/CHANGELOG.md)
- [Commits](https://github.com/aws/aws-sdk-js-v3/commits/v3.651.1/clients/client-ecr)

Updates `@aws-sdk/client-ecr-public` from 3.583.0 to 3.651.1
- [Release notes](https://github.com/aws/aws-sdk-js-v3/releases)
- [Changelog](https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-ecr-public/CHANGELOG.md)
- [Commits](https://github.com/aws/aws-sdk-js-v3/commits/v3.651.1/clients/client-ecr-public)

---
updated-dependencies:
- dependency-name: "@aws-sdk/client-ecr" dependency-type: direct:production update-type: version-update:semver-minor dependency-group: aws-sdk-dependencies
- dependency-name: "@aws-sdk/client-ecr-public" dependency-type: direct:production update-type: version-update:semver-minor dependency-group: aws-sdk-dependencies ...